### PR TITLE
fix: correct typo 'supersivor' -> 'supervisor' in notification target

### DIFF
--- a/locales/cs_CZ.po
+++ b/locales/cs_CZ.po
@@ -227,7 +227,7 @@ msgid "Supervisor of last group assigned"
 msgstr "Kontrolor poslední přiřazení skupiny"
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Poslední přiřazená skupina bez kontrolora"
 
 #: inc/ticket.class.php:435

--- a/locales/de_DE.po
+++ b/locales/de_DE.po
@@ -223,7 +223,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -223,7 +223,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/es_419.po
+++ b/locales/es_419.po
@@ -130,7 +130,7 @@ msgid "Last group assigned"
 msgstr "Último grupo asignado"
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Último grupo asignado sin supervisor"
 
 #: src/Ticket.php:125

--- a/locales/es_AR.po
+++ b/locales/es_AR.po
@@ -135,7 +135,7 @@ msgid "Last group assigned"
 msgstr "Último grupo asignado"
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Último grupo asignado sin supervisor"
 
 #: src/Ticket.php:125

--- a/locales/es_ES.po
+++ b/locales/es_ES.po
@@ -278,7 +278,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:134
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:841

--- a/locales/fi_FI.po
+++ b/locales/fi_FI.po
@@ -223,7 +223,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -134,7 +134,7 @@ msgid "Last group assigned"
 msgstr "Dernier groupe assigné"
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Dernier groupe chargé du ticket sans superviseur"
 
 #: src/Ticket.php:125

--- a/locales/glpi.pot
+++ b/locales/glpi.pot
@@ -125,7 +125,7 @@ msgid "Last group assigned"
 msgstr ""
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: src/Ticket.php:125

--- a/locales/hu_HU.po
+++ b/locales/hu_HU.po
@@ -223,7 +223,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/it_IT.po
+++ b/locales/it_IT.po
@@ -288,7 +288,7 @@ msgid "Supervisor of last group assigned"
 msgstr "Supervisore dell'ultimo gruppo assegnato"
 
 #: inc/ticket.class.php:134
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Ultimo gruppo assegnato senza supervisore"
 
 #: inc/ticket.class.php:841

--- a/locales/ja_JP.po
+++ b/locales/ja_JP.po
@@ -127,7 +127,7 @@ msgid "Last group assigned"
 msgstr "最終割り当てグループ"
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "監督抜きの最終割り当てグループ"
 
 #: src/Ticket.php:125

--- a/locales/lv_LV.po
+++ b/locales/lv_LV.po
@@ -224,7 +224,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/nl_NL.po
+++ b/locales/nl_NL.po
@@ -223,7 +223,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -103,7 +103,7 @@ msgid "Last group assigned"
 msgstr "Último grupo atribuído"
 
 #: src/Ticket.php:149
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Último grupo atribuído sem supervisor"
 
 #: src/Ticket.php:125

--- a/locales/pt_PT.po
+++ b/locales/pt_PT.po
@@ -292,7 +292,7 @@ msgid "Supervisor of last group assigned"
 msgstr "Supervisor do último grupo atribuído"
 
 #: inc/ticket.class.php:134
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Último grupo atribuído sem supervisor"
 
 #: inc/tickettask.class.php:123

--- a/locales/ro_RO.po
+++ b/locales/ro_RO.po
@@ -224,7 +224,7 @@ msgid "Supervisor of last group assigned"
 msgstr ""
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr ""
 
 #: inc/ticket.class.php:435

--- a/locales/ru_RU.po
+++ b/locales/ru_RU.po
@@ -226,7 +226,7 @@ msgid "Supervisor of last group assigned"
 msgstr "Руководитель назначенной группы"
 
 #: inc/ticket.class.php:88
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Последняя назначенная группа без руководителя"
 
 #: inc/ticket.class.php:435

--- a/locales/tr_TR.po
+++ b/locales/tr_TR.po
@@ -256,7 +256,7 @@ msgid "Supervisor of last group assigned"
 msgstr "Son atanan grubun yöneticisi"
 
 #: inc/ticket.class.php:91
-msgid "Last group assigned without supersivor"
+msgid "Last group assigned without supervisor"
 msgstr "Yöneticisiz olarak atanan son grup"
 
 #: inc/ticket.class.php:441

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -146,7 +146,7 @@ class Ticket
                 self::LAST_GROUP_ASSIGN_WITHOUT_SUPERVISOR,
                 sprintf(
                     __('%1$s (%2$s)'),
-                    __('Last group assigned without supersivor', 'behaviors'),
+                    __('Last group assigned without supervisor', 'behaviors'),
                     __('Behaviours', 'behaviors')
                 )
             );


### PR DESCRIPTION
## Problem
The notification target "Last group assigned without supervisor" had a typo
('supersivor') in the PHP source string and all 18 locale files.

## Changes
- `src/Ticket.php`: fix source string
- `locales/glpi.pot`: fix template
- `locales/*.po`: fix all 18 translation files (msgid only — translations untouched)

Note: `.mo` files will be regenerated by the generatemo workflow on merge.