### PR TITLE
fix: replace duplicate use_assign_user_group_update with single_tech_…

### DIFF
--- a/templates/config.html.twig
+++ b/templates/config.html.twig
@@ -116,8 +116,8 @@
                 {% set tab = {0: __("No"), 1: __('Single user and single group', 'behaviors'), 2: __('Single user or group', 'behaviors')} %}
 
                 {{ fields.dropdownArrayField(
-                    'use_assign_user_group_update',
-                    config["use_assign_user_group_update"],
+                    'single_tech_mode',
+                    config["single_tech_mode"],
                     tab,
                     __("Single technician and group", "behaviors"),
                     field_options


### PR DESCRIPTION
The 'Update of a ticket' section rendered use_assign_user_group_update twice — once correctly as 'Use the technician\'s group' (No/First/Last) and again incorrectly labeled as 'Single technician and group' using the same field name.

The second dropdown was intended for single_tech_mode (int field, already present in DB schema) which controls whether only one technician/group can be assigned. The $tab options (No / Single user and single group / Single user or group) match single_tech_mode exactly.

Fixes: config form silently ignoring single_tech_mode value.