### PR TITLE
Refactor/hooks use constants

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -47,6 +47,7 @@ use GlpiPlugin\Behaviors\Change;
 use GlpiPlugin\Behaviors\ChangeTask;
 use GlpiPlugin\Behaviors\Problem;
 use GlpiPlugin\Behaviors\ProblemTask;
+use Glpi\Plugin\Hooks;
 
 define('PLUGIN_BEHAVIORS_VERSION', '3.0.4');
 // Init the hooks of the plugins -Needed
@@ -55,9 +56,9 @@ function plugin_init_behaviors()
     global $PLUGIN_HOOKS;
 
     Plugin::registerClass(Config::class, ['addtabon' => 'Config']);
-    $PLUGIN_HOOKS['config_page']['behaviors'] = 'front/config.form.php';
+    $PLUGIN_HOOKS[Hooks::CONFIG_PAGE]['behaviors'] = 'front/config.form.php';
 
-    $PLUGIN_HOOKS['item_add']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_ADD]['behaviors']
         = [
             \Ticket_User::class => [Ticket_User::class, 'afterAdd'],
             \Group_Ticket::class => [Group_Ticket::class, 'afterAdd'],
@@ -66,10 +67,10 @@ function plugin_init_behaviors()
             \ITILSolution::class => [ITILSolution::class, 'afterAdd'],
         ];
 
-    $PLUGIN_HOOKS['item_update']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_UPDATE]['behaviors']
         = [\Ticket::class => [Ticket::class, 'afterUpdate']];
 
-    $PLUGIN_HOOKS['pre_item_add']['behaviors']
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_ADD]['behaviors']
         = [
             \Ticket::class => [Ticket::class, 'beforeAdd'],
             \ITILSolution::class => [ITILSolution::class, 'beforeAdd'],
@@ -78,10 +79,10 @@ function plugin_init_behaviors()
             \ITILFollowup::class => [ITILFollowup::class, 'beforeAdd'],
         ];
 
-    $PLUGIN_HOOKS['post_prepareadd']['behaviors']
+    $PLUGIN_HOOKS[Hooks::POST_PREPAREADD]['behaviors']
         = [\Ticket::class => [Ticket::class, 'afterPrepareAdd']];
 
-    $PLUGIN_HOOKS['pre_item_update']['behaviors']
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['behaviors']
         = [
             \Problem::class => [Problem::class, 'beforeUpdate'],
             \Ticket::class => [Ticket::class, 'beforeUpdate'],
@@ -92,29 +93,29 @@ function plugin_init_behaviors()
             \ProblemTask::class => [ProblemTask::class, 'beforeUpdate'],
         ];
 
-    $PLUGIN_HOOKS['pre_item_purge']['behaviors']
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_PURGE]['behaviors']
         = [\Computer::class => [Computer::class, 'beforePurge']];
 
-    $PLUGIN_HOOKS['item_purge']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_PURGE]['behaviors']
         = [\Document_Item::class => [Document_Item::class, 'afterPurge']];
 
     // Notifications
-    $PLUGIN_HOOKS['item_get_events']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_GET_EVENTS]['behaviors']
         = ['NotificationTargetTicket' => [Ticket::class, 'addEvents']];
 
-    $PLUGIN_HOOKS['item_add_targets']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_ADD_TARGETS]['behaviors']
         = ['NotificationTargetTicket' => [Ticket::class, 'addTargets']];
 
-    $PLUGIN_HOOKS['item_action_targets']['behaviors']
+    $PLUGIN_HOOKS[Hooks::ITEM_ACTION_TARGETS]['behaviors']
         = ['NotificationTargetTicket' => [Ticket::class, 'addActionTargets']];
 
-    $PLUGIN_HOOKS['pre_item_form']['behaviors'] = [Common::class, 'messageWarning'];
-    $PLUGIN_HOOKS['post_item_form']['behaviors'] = [Common::class, 'deleteAddSolutionButton'];
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_FORM]['behaviors'] = [Common::class, 'messageWarning'];
+    $PLUGIN_HOOKS[Hooks::POST_ITEM_FORM]['behaviors'] = [Common::class, 'deleteAddSolutionButton'];
 
     // End init, when all types are registered
-    $PLUGIN_HOOKS['post_init']['behaviors'] = [Common::class, 'postInit'];
+    $PLUGIN_HOOKS[Hooks::POST_INIT]['behaviors'] = [Common::class, 'postInit'];
 
-    $PLUGIN_HOOKS['csrf_compliant']['behaviors'] = true;
+    $PLUGIN_HOOKS[Hooks::CSRF_COMPLIANT]['behaviors'] = true;
 
     //TO Disable in v11
     //    foreach ($CFG_GLPI["asset_types"] as $type) {

--- a/src/Common.php
+++ b/src/Common.php
@@ -41,7 +41,6 @@ use Dropdown;
 use Html;
 use Log;
 use Plugin;
-use PluginMoreticketConfig;
 use Session;
 use Toolbox;
 
@@ -315,11 +314,11 @@ class Common extends CommonGLPI
             $mandatory_solution = false;
             if ($config->getField('is_ticketrealtime_mandatory')) {
                 // for moreTicket plugin
-                $plugin = new Plugin();
-                if ($plugin->isActivated('moreticket')) {
-                    $configmoreticket = new PluginMoreticketConfig();
+		$plugin = new Plugin();
+		if ($plugin->isActivated('moreticket') && class_exists('PluginMoreticketConfig')) {
+    		    $configmoreticket = new PluginMoreticketConfig();
                     $mandatory_solution = $configmoreticket->isMandatorysolution();
-                }
+		}
 
                 if (($dur == 0) && ($mandatory_solution == false)) {
                     $warnings[] = __("Duration is mandatory before ticket is solved/closed", 'behaviors');

--- a/templates/config.html.twig
+++ b/templates/config.html.twig
@@ -116,8 +116,8 @@
                 {% set tab = {0: __("No"), 1: __('Single user and single group', 'behaviors'), 2: __('Single user or group', 'behaviors')} %}
 
                 {{ fields.dropdownArrayField(
-                    'use_assign_user_group_update',
-                    config["use_assign_user_group_update"],
+                    'single_tech_mode',
+                    config["single_tech_mode"],
                     tab,
                     __("Single technician and group", "behaviors"),
                     field_options


### PR DESCRIPTION
GLPI 11 recommends using typed constants from Glpi\Plugin\Hooks
instead of bare string literals for \$PLUGIN_HOOKS keys.

Migrated 15 hooks:
- CONFIG_PAGE, CSRF_COMPLIANT, POST_INIT
- ITEM_ADD, ITEM_UPDATE, ITEM_PURGE
- PRE_ITEM_ADD, PRE_ITEM_UPDATE, PRE_ITEM_PURGE
- POST_PREPAREADD
- ITEM_GET_EVENTS, ITEM_ADD_TARGETS, ITEM_ACTION_TARGETS
- PRE_ITEM_FORM, POST_ITEM_FORM"
