### PR TITLE
fix: cast AUTO_INCREMENT target value to int in Ticket and Change

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -64,7 +64,7 @@ class Change
             foreach ($DB->request($sql) as $data) {
                 $max = $data['max'];
             }
-            $want = date($config->getField('changes_id_format'));
+            $want = (int) date($config->getField('changes_id_format'));
             if ($max < $want) {
                 $DB->doQuery("ALTER TABLE `glpi_changes` AUTO_INCREMENT=$want");
             }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -421,7 +421,7 @@ class Ticket
             foreach ($DB->request($sql) as $data) {
                 $max = $data['max'];
             }
-            $want = date($config->getField('tickets_id_format'));
+            $want = (int) date($config->getField('tickets_id_format'));
             if ($max < $want) {
                 $DB->doQuery("ALTER TABLE `glpi_tickets` AUTO_INCREMENT=$want");
             }


### PR DESCRIPTION
date() returns a numeric string which is safe but not explicitly typed. Adding (int) cast makes the intent clear and prevents any potential type coercion issues when comparing $max < $want across PHP versions.

doQuery() is the correct approach here — ALTER TABLE AUTO_INCREMENT has no DBAL query builder equivalent and the value is now explicitly an integer so there is no injection risk.