### PR TITLE
refactor: migrate messageWarning() and deleteAddSolutionButton() to Twig

### DIFF
--- a/src/Common.php
+++ b/src/Common.php
@@ -420,84 +420,46 @@ class Common extends CommonGLPI
      *
      * @param $params
      **/
-    public static function messageWarning($params)
-    {
-        if (isset($params['item'])) {
-            $item = $params['item'];
-            if ($item->getType() == 'ITILSolution') {
-                $warnings = self::checkWarnings($params);
-                $config = Config::getInstance();
-                $parentitem = $params['options']['item'];
-                if ((is_array($warnings) && count($warnings))
-                    || $config->getField('is_ticketsolution_mandatory')
-                    || $config->getField('is_ticketsolutiontype_mandatory')) {
-                    echo "<div class='alert alert-warning'>";
+     public static function messageWarning($params)
+     {
+     	if (isset($params['item'])) {
+        	$item = $params['item'];
 
-                    echo "<div style='display:flex;align-items: center;'>";
+        	if ($item->getType() == 'ITILSolution') {
+            		$warnings = self::checkWarnings($params);
+            		$config = Config::getInstance();
+            		$parentitem = $params['options']['item'];
 
-                    echo "<div style='margin-right: 20px;'>";
-                    echo "<i class='ti ti-alert-triangle' style='font-size:2em;color:orange;vertical-align: top;'></i>";
-                    echo "</div>";
+            		$show_solution_mandatory = $config->getField('is_ticketsolution_mandatory')
+                	   && is_array($warnings)
+                	   && count($warnings) == 0
+                           && $parentitem->getType() == 'Ticket';
 
-                    echo "<div>";
-                    if ($config->getField('is_ticketsolution_mandatory')
-                        && is_array($warnings)
-                        && count($warnings) == 0
-                    && $parentitem->getType() == 'Ticket') {
-                        echo "<h4 class='alert-title'>" . __(
-                            "You must add a description. it's mandatory",
-                            'behaviors'
-                        ) . "</h4>";
-                    }
-                    if ($config->getField('is_ticketsolutiontype_mandatory') && is_array($warnings) && count($warnings) == 0) {
-                        echo "<h4 class='alert-title'>" . __(
-                            "You must add a solution type. it's mandatory",
-                            'behaviors'
-                        ) . "</h4>";
-                    }
-                    if (is_array($warnings) && count($warnings)) {
-                        if ($parentitem->getType() == 'Ticket') {
-                            echo "<h4 class='alert-title'>" . __('You cannot resolve the ticket', 'behaviors') . " :</h4>";
-                        } elseif ($parentitem->getType() == 'Problem') {
-                            echo "<h4 class='alert-title'>" . __('You cannot resolve the problem', 'behaviors') . " :</h4>";
-                        } elseif ($parentitem->getType() == 'Change') {
-                            echo "<h4 class='alert-title'>" . __('You cannot resolve the change', 'behaviors') . " :</h4>";
-                        }
+            		$show_solutiontype_mandatory = $config->getField('is_ticketsolutiontype_mandatory')
+                	   && is_array($warnings)
+                           && count($warnings) == 0;
 
-                        echo "<div class='text-muted'>" . implode('</div><div>', $warnings) . "</div>";
-                    }
-                    echo "</div>";
+            		if ($show_solution_mandatory || $show_solutiontype_mandatory || (is_array($warnings) && count($warnings))) {
+                		TemplateRenderer::getInstance()->display(
+                    			'@behaviors/warning_solution.html.twig',
+                    			[
+                        			'warnings'                  => is_array($warnings) ? $warnings : [],
+                        			'parent_type'               => $parentitem->getType(),
+                        			'show_solution_mandatory'   => $show_solution_mandatory,
+                        			'show_solutiontype_mandatory' => $show_solutiontype_mandatory,
+                    			]
+                		);
+            		}
+        	} elseif ($item->getType() == 'TicketTask') {
+            		$config = Config::getInstance();
+            		if ($config->getField('is_tickettaskcategory_mandatory')) {
+                		TemplateRenderer::getInstance()->display('@behaviors/warning_task.html.twig', []);
+            		}
+        	}
+    	}
+    	return $params;
+     }
 
-                    echo "</div>";
-
-                    echo "</div>";
-                }
-            } elseif ($item->getType() == 'TicketTask') {
-                $config = Config::getInstance();
-                if ($config->getField('is_tickettaskcategory_mandatory')) {
-                    echo "<div class='alert alert-warning'>";
-
-                    echo "<div class='d-flex'>";
-
-                    echo "<div class='me-2'>";
-                    echo "<i class='ti ti-alert-triangle' style='font-size:2em;color:orange'></i>";
-                    echo "</div>";
-
-                    echo "<div>";
-                    echo "<h4 class='alert-title'>" . __(
-                        "You must define a category. it's mandatory",
-                        'behaviors'
-                    ) . "</h4>";
-                    echo "</div>";
-
-                    echo "</div>";
-
-                    echo "</div>";
-                }
-            }
-        }
-        return $params;
-    }
 
 
     /**
@@ -506,54 +468,21 @@ class Common extends CommonGLPI
      * @param $params
      *
      * @return array
-     **/
-    public static function deleteAddSolutionButton($params)
-    {
-        if (isset($params['item'])) {
-            $item = $params['item'];
-            if ($item->getType() == 'ITILSolution') {
-                //                $options = $params['options'];
-                //                $config = Config::getInstance();
-                //                if ($config->getField('is_ticketrealtime_mandatory')) {
-                //                    $ticket = $options['item'];
-                //                    echo "<div class='row mx-n3 mx-xxl-auto'>";
-                //                    echo "<div class='col-12 mb-3'>";
-                //                    echo __('Duration');
-                //                    echo "&nbsp;<span style='color:red'>*</span>&nbsp;";
-                //
-                //                    $rand = mt_rand();
-                //                    echo "<span id='duration_solution_" . $rand . $ticket->fields['id'] . "'>";
-                //                    $toadd = [];
-                //                    for ($i = 9; $i <= 100; $i++) {
-                //                        $toadd[] = $i * HOUR_TIMESTAMP;
-                //                    }
-                //                    echo Html::scriptBlock(
-                //                        "function showsolutionbutton(){
-                //                                 $('.itilsolution').children().find(':submit').show();
-                //                              }"
-                //                    );
-                //
-                //                    Dropdown::showTimeStamp("duration_solution", [
-                //                        'min' => 0,
-                //                        'max' => 8 * HOUR_TIMESTAMP,
-                //                        'inhours' => true,
-                //                        'toadd' => $toadd,
-                //                        'on_change' => 'showsolutionbutton();'
-                //                    ]);
-                //
-                //                    echo "</span>";
-                //                    echo "</div>";
-                //                    echo "</div>";
-                //                }
-                $warnings = self::checkWarnings($params);
-                if (is_array($warnings) && count($warnings) > 0) {
-                    echo Html::scriptBlock(
-                        "$(document).ready(function(){
-                        $('.itilsolution').children().find(':submit').hide();
-                     });"
-                    );
-                }
-            }
-        }
-    }
+     /**/
+	public static function deleteAddSolutionButton($params)
+	{
+    		if (isset($params['item'])) {
+        		$item = $params['item'];
+        		if ($item->getType() == 'ITILSolution') {
+            			$warnings = self::checkWarnings($params);
+            			if (is_array($warnings) && count($warnings) > 0) {
+                			TemplateRenderer::getInstance()->display(
+                    			'@behaviors/warning_hide_submit.html.twig',
+                    			[]
+                			);
+            			}
+        		}
+    		}
+	}
+
 }

--- a/templates/warning_hide_submit.html.twig
+++ b/templates/warning_hide_submit.html.twig
@@ -1,0 +1,5 @@
+<script>
+$(document).ready(function(){
+    $('.itilsolution').children().find(':submit').hide();
+});
+</script>

--- a/templates/warning_solution.html.twig
+++ b/templates/warning_solution.html.twig
@@ -1,0 +1,58 @@
+{#
+# -------------------------------------------------------------------------
+# Behaviors plugin for GLPI
+# -------------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of Behaviors.
+#
+# Behaviors is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Behaviors is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Behaviors. If not, see <http://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------
+# @copyright Copyright (C) 2018-2025 by Behaviors plugin team.
+# @license   AGPLv3 https://www.gnu.org/licenses/agpl-3.0.html
+# @link      https://github.com/InfotelGLPI/Behaviors
+# -------------------------------------------------------------------------
+#}
+<div class="alert alert-warning">
+    <div class="d-flex align-items-center">
+        <div class="me-3">
+            <i class="ti ti-alert-triangle" style="font-size:2em;color:orange"></i>
+        </div>
+        <div>
+            {% if show_solution_mandatory %}
+                <h4 class="alert-title">{{ __("You must add a description. it's mandatory", 'behaviors') }}</h4>
+            {% endif %}
+
+            {% if show_solutiontype_mandatory %}
+                <h4 class="alert-title">{{ __("You must add a solution type. it's mandatory", 'behaviors') }}</h4>
+            {% endif %}
+
+            {% if warnings|length > 0 %}
+                <h4 class="alert-title">
+                    {% if parent_type == 'Ticket' %}
+                        {{ __('You cannot resolve the ticket', 'behaviors') }} :
+                    {% elseif parent_type == 'Problem' %}
+                        {{ __('You cannot resolve the problem', 'behaviors') }} :
+                    {% elseif parent_type == 'Change' %}
+                        {{ __('You cannot resolve the change', 'behaviors') }} :
+                    {% endif %}
+                </h4>
+                {% for warning in warnings %}
+                    <div class="text-muted">{{ warning }}</div>
+                {% endfor %}
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/templates/warning_task.html.twig
+++ b/templates/warning_task.html.twig
@@ -1,0 +1,37 @@
+{#
+# -------------------------------------------------------------------------
+# Behaviors plugin for GLPI
+# -------------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of Behaviors.
+#
+# Behaviors is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Behaviors is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Behaviors. If not, see <http://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------
+# @copyright Copyright (C) 2018-2025 by Behaviors plugin team.
+# @license   AGPLv3 https://www.gnu.org/licenses/agpl-3.0.html
+# @link      https://github.com/InfotelGLPI/Behaviors
+# -------------------------------------------------------------------------
+#}
+<div class="alert alert-warning">
+    <div class="d-flex align-items-center">
+        <div class="me-3">
+            <i class="ti ti-alert-triangle" style="font-size:2em;color:orange"></i>
+        </div>
+        <div>
+            <h4 class="alert-title">{{ __("You must define a category. it's mandatory", 'behaviors') }}</h4>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Replace all echo HTML in Common.php warning methods with Twig templates:

- templates/warning_solution.html.twig: ITILSolution pre-form warning (mandatory description, mandatory solution type, blocking conditions)
- templates/warning_task.html.twig: TicketTask mandatory category warning
- templates/warning_hide_submit.html.twig: JS to hide submit button when blocking conditions are present

Logic (checkWarnings, condition checks) is unchanged — only the rendering layer is migrated from echo to TemplateRenderer.