### PR TITLE
chore: add composer.json with PSR-4 autoload declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "infotelglpi/behaviors",
+    "type": "glpi-plugin",
+    "description": "This plugin allows you to add optional behaviors to GLPI.",
+    "homepage": "https://github.com/InfotelGLPI/behaviors",
+    "license": "AGPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "Infotel"
+        },
+        {
+            "name": "Remi Collet"
+        },
+        {
+            "name": "Nelly Mahu-Lasson"
+        }
+    ],
+    "require": {
+        "php": ">=8.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "GlpiPlugin\\Behaviors\\": "src/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
Adds the missing composer.json required by GLPI 11 plugin standards. Declares the PSR-4 autoload mapping for GlpiPlugin\Behaviors -> src/ and sets PHP >= 8.1 as the minimum runtime requirement, consistent with GLPI 11 minimum PHP version.